### PR TITLE
SimpleLib DevOps

### DIFF
--- a/DevOps/Dockerfile
+++ b/DevOps/Dockerfile
@@ -1,0 +1,73 @@
+# escape=`
+# ^^ set different escape char since Windows uses `\` a lot
+
+
+#################################################################
+#                    * Topas Test DockerFile *                  #
+# ------------------------------------------------------------- #
+# Authors: David Leek                                           #
+# Notes  : Dockerfile for Build 'n Run of Topaz Labs' Test Repo #
+#################################################################
+
+
+
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+# Set Specific versioning in the file so you don't have unexpected changes
+# e.g. - microsoft/mindowsservercore might get a random version
+
+LABEL maintainer="rhynri@me.com"
+
+# Vars
+ENV BUILD_PATH "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools"
+
+# Restore the default Windows shell for correct batch processing.
+SHELL ["cmd", "/S", "/C"]
+
+# Install the Build Tools...
+# See: https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2019
+RUN `
+    # Download the Build Tools bootstrapper.
+    curl -SL --output vs_buildtools.exe https://aka.ms/vs/16/release/vs_buildtools.exe `
+    `
+    # Install Build Tools with the VC Tools workload. 
+    # Excluding workloads and components with known issues.
+    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify `
+        --installPath "%BUILD_PATH%" `
+        --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        --add Microsoft.VisualStudio.Component.Windows10SDK.18362 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+        --remove Microsoft.VisualStudio.Component.Windows81SDK `
+        || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
+    `
+    # Cleanup
+    && del /q vs_buildtools.exe
+
+# Set some things in our path - could do this as a one line but it's easier to read.
+RUN setx /M PATH "%PATH%%BUILD_PATH%\VC\Tools\MSVC\14.29.30037\bin\Hostx64\x64"
+RUN setx /M PATH "%PATH%%BUILD_PATH%\VC\Auxiliary\Build"
+
+RUN mkdir Code `
+    && cd Code `
+    && curl -SLO --output master.zip https://github.com/TopazLabs/SimpleLib/archive/master.zip `
+    && tar -xf master.zip `
+    && del /q master.zip
+
+WORKDIR "C:\Code\SimpleLib-master"
+
+# Compile this thing
+# If you had a .sln file, you could use a single command `msbuild` here
+# or a .spec file or something equivalent to that
+# That'd also take care of your dependencies.
+
+# Set VC Vars to x64
+RUN vcvarsall.bat x64 `
+    && cl /c /EHsc fiblib.cpp `
+    && lib fiblib.obj `
+    && cl /EHsc main.cpp fiblib.lib
+
+# OPTIONAL: Set an entrypoint that causes the docker to barf out our answer
+#ENTRYPOINT ["main", "42"]
+
+ENTRYPOINT ["cmd.exe"]

--- a/DevOps/Dockerfile
+++ b/DevOps/Dockerfile
@@ -1,15 +1,13 @@
 # escape=`
 # ^^ set different escape char since Windows uses `\` a lot
 
-
 #################################################################
 #                    * Topas Test DockerFile *                  #
 # ------------------------------------------------------------- #
 # Authors: David Leek                                           #
 # Notes  : Dockerfile for Build 'n Run of Topaz Labs' Test Repo #
+# Usage  : See README.md                                        #
 #################################################################
-
-
 
 FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
 # Set Specific versioning in the file so you don't have unexpected changes

--- a/DevOps/README.md
+++ b/DevOps/README.md
@@ -1,0 +1,16 @@
+# SimpleLib Docker
+
+This is a not-so-simple docker that does an in-place build of SimpleLib
+
+## Usage
+- If you have been using Linux containers, you may have to right click 
+  Docker Desktop and click "Switch to Windows Containers"
+
+- You'll also need to set some env vars:
+    `set DOCKER_BUILDKIT=0`
+    `set COMPOSE_DOCKER_CLI_BUILD=0`
+  or equivalent lines in your docker comfig thanks to a Docker bug
+
+- Use `docker build -t topaz-test .` to build
+- Use `docker run -it topaz-test` to get a cmd then just type `main {arg}` to test  
+- OR uncomment the entrypoint near the bottom and just use the run command

--- a/DevOps/azure-pipelines.yml
+++ b/DevOps/azure-pipelines.yml
@@ -1,0 +1,56 @@
+#             * Azure DevOps Topaz Packaging Pipeline *             #
+# ----------------------------------------------------------------- #
+# Authors: David Leek        									                     	#
+# Notes  : Mock Azure DevOps Pipeline for Topaz Test                #
+#####################################################################
+
+variables:
+  version: 1.0.0
+  configuration: Release
+  isPullRequest: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
+  env_name: test
+
+name: Topaz_$(SourceBranchName)_$(version)_$(env_name).$(Build.BuildId)
+
+pool:
+  vmImage: 'windows-2019'
+
+trigger:
+- master
+
+stages:
+  - stage: Compile_Cpp
+    displayName: Compile C++ Code
+    jobs:
+    - job: x64_Compile
+      displayName: Compile Topaz x64 C++
+      steps:
+      
+  # Build C++
+  # if you had a .sln file, you could use an MSBuild task for this
+  # you could also make a batch file and run it instead of an inline
+  # 
+  # No need for vcvars here since the CLI is a VS Dev one by default
+      - script: |
+          cl /c /EHsc fiblib.cpp
+          lib fiblib.obj
+          cl /EHsc main.cpp fiblib.lib
+        displayName: Compilation 
+        
+  # Copy to output folder - this allows you to clean up files
+      - task: CopyFiles@2
+        displayName: 'Copy x64 Artifacts'
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)'
+          Contents: '**\main*'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+          CleanTargetFolder: true
+          OverWrite: true
+          
+  # Publish to Artifactory
+      - task: PublishBuildArtifacts@1
+        displayName: Publish C++ x64 Artifacts
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'test'
+          publishLocation: 'Container'

--- a/DevOps/azure-pipelines.yml
+++ b/DevOps/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
         displayName: 'Copy x64 Artifacts'
         inputs:
           SourceFolder: '$(Build.SourcesDirectory)'
-          Contents: '**\main*'
+          Contents: '**\main.exe'
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
           CleanTargetFolder: true
           OverWrite: true


### PR DESCRIPTION
# Docker 'Just Send It' with Bonus
_Requires Docker Desktop to be in `Windows Container` mode._

Adds some functionality to the repo in the form of a Dockerfile that allows you to compile in place with an optional EntryPoint that makes the `docker run` command just spit out answers. 

See the `README.md` for usage.  

### Why docker and not AWS?  
- [ ] AWS Credentials Emailed by a _Certain Someone_
- [ ] AWS Accounts Personally Owned
- [ ] Bothering Someone on the Weekend
- [X] Implementing Windows-based containers for fun
- [X] Nerd Humor in Checkbox Form

## Bonus
A probably-functional `azure-pipelines.yml` that does the same thing. 

I say "probably functional" because pipelines are "Fail your way to Success" and **insufficient failure has been had.**
_[i.e. - I haven't run it yet]_